### PR TITLE
Use fingerprint hash fragment as key id.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,23 +51,23 @@ That DID would correspond to the following DID Document:
   "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
   "publicKey": [
     {
-      "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+      "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
       "type": "Ed25519VerificationKey2018",
       "controller": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
       "publicKeyBase58": "B12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u"
     }
   ],
   "authentication": [
-    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
   ],
   "assertionMethod": [
-    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
   ],
   "capabilityDelegation": [
-    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
   ],
   "capabilityInvocation": [
-    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
   ],
   "keyAgreement": [
     {
@@ -117,7 +117,7 @@ const didKeyDriver = require('did-method-key').driver();
 
 const didDocument = await didKeyDriver.generate(); // Ed25519 key type by default
 
-JSON.stringify(didDocument, null, 2);
+console.log(JSON.stringify(didDocument, null, 2));
 ```
 
 To get a DID Document for an existing `did:key` DID:

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -46,24 +46,26 @@ async function generate({keyType = 'Ed25519VerificationKey2018'} = {}) {
  */
 function keyToDidDoc(edKey) {
   const did = `did:key:${edKey.fingerprint()}`;
+  const keyId = `${did}#${edKey.fingerprint()}`;
   edKey.controller = did;
 
   const dhKey = X25519KeyPair.fromEdKeyPair(edKey);
   dhKey.id = `${did}#${dhKey.fingerprint()}`;
 
+
   return {
     '@context': 'https://w3id.org/did/v1',
     id: did,
     publicKey: [{
-      id: did,
+      id: keyId,
       type: edKey.type,
       controller: did,
       publicKeyBase58: edKey.publicKeyBase58
     }],
-    authentication: [did],
-    assertionMethod: [did],
-    capabilityDelegation: [did],
-    capabilityInvocation: [did],
+    authentication: [keyId],
+    assertionMethod: [keyId],
+    capabilityDelegation: [keyId],
+    capabilityInvocation: [keyId],
     keyAgreement: [{
       id: dhKey.id,
       type: dhKey.type,

--- a/tests/driver.spec.js
+++ b/tests/driver.spec.js
@@ -13,25 +13,18 @@ describe('did:key method driver', () => {
   describe('get', () => {
     it('should get a did:key DID', async () => {
       const did = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+      const keyId = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
       const didDoc = await didKeyDriver.get({did});
 
       expect(didDoc.id).to.equal(did);
       expect(didDoc['@context']).to.equal('https://w3id.org/did/v1');
-      expect(didDoc.authentication).to.eql([
-        'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH'
-      ]);
-      expect(didDoc.assertionMethod).to.eql([
-        'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH'
-      ]);
-      expect(didDoc.capabilityDelegation).to.eql([
-        'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH'
-      ]);
-      expect(didDoc.capabilityInvocation).to.eql([
-        'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH'
-      ]);
+      expect(didDoc.authentication).to.eql([keyId]);
+      expect(didDoc.assertionMethod).to.eql([keyId]);
+      expect(didDoc.capabilityDelegation).to.eql([keyId]);
+      expect(didDoc.capabilityInvocation).to.eql([keyId]);
 
       const [publicKey] = didDoc.publicKey;
-      expect(publicKey.id).to.equal(did);
+      expect(publicKey.id).to.equal(keyId);
       expect(publicKey.type).to.equal('Ed25519VerificationKey2018');
       expect(publicKey.controller).to.equal(did);
       expect(publicKey.publicKeyBase58).to


### PR DESCRIPTION
Fixes issue #3.

Update `did:key` method did docs to use the usual `${did}#${fingerprint}` pattern (to match the X25519 key, and Veres keys).