### PR TITLE
Add setKeyId() and methodId to did:key driver.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "8"
-  - "10"
   - "12"
 sudo: false
 script:

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -128,15 +128,14 @@ function keyToDidDoc(edKey) {
 }
 
 /**
- * Sets the id of a given key. Used by `did-io` drivers.
+ * Computes and returns the id of a given key. Used by `did-io` drivers.
  *
  * @param {LDKeyPair} key
  *
  * @returns {string} Returns the key's id.
  */
-function setKeyId({key}) {
-  key.id = `did:key:${key.fingerprint()}#${key.fingerprint()}`;
-  return key.id;
+async function computeKeyId({key}) {
+  return `did:key:${key.fingerprint()}#${key.fingerprint()}`;
 }
 
 module.exports = {
@@ -144,5 +143,5 @@ module.exports = {
   get,
   generate,
   keyToDidDoc,
-  setKeyId,
+  computeKeyId
 }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -127,8 +127,22 @@ function keyToDidDoc(edKey) {
   };
 }
 
+/**
+ * Sets the id of a given key. Used by `did-io` drivers.
+ *
+ * @param {LDKeyPair} key
+ *
+ * @returns {string} Returns the key's id.
+ */
+function setKeyId({key}) {
+  key.id = `did:key:${key.fingerprint()}#${key.fingerprint()}`;
+  return key.id;
+}
+
 module.exports = {
+  methodId: 'key', // used by did-io to register drivers
   get,
   generate,
-  keyToDidDoc
+  keyToDidDoc,
+  setKeyId,
 }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -139,7 +139,7 @@ async function computeKeyId({key}) {
 }
 
 module.exports = {
-  methodId: 'key', // used by did-io to register drivers
+  method: 'key', // used by did-io to register drivers
   get,
   generate,
   keyToDidDoc,

--- a/tests/driver.spec.js
+++ b/tests/driver.spec.js
@@ -91,9 +91,9 @@ describe('did:key method driver', () => {
     });
   });
 
-  describe('methodId', () => {
+  describe('method', () => {
     it('should return did method id', () => {
-      expect(didKeyDriver.methodId).to.equal('key');
+      expect(didKeyDriver.method).to.equal('key');
     });
   });
 });

--- a/tests/driver.spec.js
+++ b/tests/driver.spec.js
@@ -79,13 +79,13 @@ describe('did:key method driver', () => {
     });
   });
 
-  describe('setKeyId', () => {
+  describe('computeKeyId', () => {
     const key = {
       fingerprint: () => '12345'
     };
 
-    it('should set the key id based on fingerprint', () => {
-      didKeyDriver.setKeyId({key});
+    it('should set the key id based on fingerprint', async () => {
+      key.id = await didKeyDriver.computeKeyId({key});
 
       expect(key.id).to.equal('did:key:12345#12345');
     });

--- a/tests/driver.spec.js
+++ b/tests/driver.spec.js
@@ -78,4 +78,22 @@ describe('did:key method driver', () => {
       expect(fetchedDidDoc).to.eql(genDidDoc);
     });
   });
+
+  describe('setKeyId', () => {
+    const key = {
+      fingerprint: () => '12345'
+    };
+
+    it('should set the key id based on fingerprint', () => {
+      didKeyDriver.setKeyId({key});
+
+      expect(key.id).to.equal('did:key:12345#12345');
+    });
+  });
+
+  describe('methodId', () => {
+    it('should return did method id', () => {
+      expect(didKeyDriver.methodId).to.equal('key');
+    });
+  });
 });


### PR DESCRIPTION
For use with `did-io` and bedrock-profile.