### PR TITLE
Avoid mutation of ed25519 key passed into keyToDidDoc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # did:key driver ChangeLog
 
+## 0.7.1 - 2021-01-21
+
+### Added
+
+- Add `keypairs` property that indexes verification methods.
+
+### Changed
+- Avoid mutation of ed25519 key passed into keyToDidDoc.
+- Set `id` field for keypairs.
+
 ## 0.7.0 - 2020-09-23
 
 ### Added

--- a/lib/Driver.js
+++ b/lib/Driver.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-const {LDKeyPair} = require('crypto-ld');
+const {Ed25519KeyPair, LDKeyPair} = require('crypto-ld');
 const {X25519KeyPair} = require('x25519-key-pair');
 const {constants: securityConstants} = require('security-context');
 const LRU = require('lru-cache');
@@ -90,41 +90,57 @@ module.exports = class Driver {
   /**
    * Converts an Ed25519KeyPair object to a `did:key` method DID Document.
    *
-   * @param {Ed25519KeyPair} edKey
+   * @param {Ed25519KeyPair} ed25519Key
    * @returns {DidDocument}
    */
-  async keyToDidDoc(edKey) {
+  async keyToDidDoc(ed25519Key) {
+    const edKey = new Ed25519KeyPair({
+      publicKeyBase58: ed25519Key.publicKey,
+      privateKeyBase58: ed25519Key.privateKey,
+    });
     const did = `did:key:${edKey.fingerprint()}`;
-    const keyId = `${did}#${edKey.fingerprint()}`;
+    edKey.id = `${did}#${edKey.fingerprint()}`;
     edKey.controller = did;
 
     const dhKey = await X25519KeyPair.fromEdKeyPair(edKey);
     dhKey.id = `${did}#${dhKey.fingerprint()}`;
+    dhKey.controller = did;
 
+    // get the public components of each keypair
+    const publicEdKey = this.getPublicVerificationMethod({key: edKey});
+    const publicDhKey = this.getPublicVerificationMethod({key: dhKey});
+
+    // generate the DID Document
     const didDoc = {
       '@context': ['https://w3id.org/did/v0.11'],
       id: did,
-      publicKey: [{
-        id: keyId,
-        type: edKey.type,
-        controller: did,
-        publicKeyBase58: edKey.publicKeyBase58
-      }],
-      authentication: [keyId],
-      assertionMethod: [keyId],
-      capabilityDelegation: [keyId],
-      capabilityInvocation: [keyId],
-      keyAgreement: [{
-        id: dhKey.id,
-        type: dhKey.type,
-        controller: did,
-        publicKeyBase58: dhKey.publicKeyBase58
-      }]
+      publicKey: [publicEdKey], // FIXME: publicKey is deprecated, remove
+      verificationMethod: [publicEdKey],
+      authentication: [publicEdKey.id],
+      assertionMethod: [publicEdKey.id],
+      capabilityDelegation: [publicEdKey.id],
+      capabilityInvocation: [publicEdKey.id],
+      keyAgreement: [publicDhKey],
     };
+    // FIXME: 'keys' is misleading as devs might think 'public keys'; remove
     Object.defineProperty(didDoc, 'keys', {
       value: {
-        [keyId]: edKey,
+        [edKey.id]: edKey,
         [dhKey.id]: dhKey
+      },
+      enumerable: false
+    });
+    Object.defineProperty(didDoc, 'keypairs', {
+      value: {
+        [edKey.id]: edKey,
+        [dhKey.id]: dhKey,
+        publicKey: [edKey],
+        verificationMethod: [edKey],
+        authentication: [edKey],
+        assertionMethod: [edKey],
+        capabilityDelegation: [edKey],
+        capabilityInvocation: [edKey],
+        keyAgreement: [dhKey],
       },
       enumerable: false
     });
@@ -139,8 +155,20 @@ module.exports = class Driver {
    *
    * @returns {string} Returns the key's id.
    */
-  async computeKeyId({key}) {
+  computeKeyId({key}) {
     return `did:key:${key.fingerprint()}#${key.fingerprint()}`;
+  }
+
+  /**
+   * Generates a public verification method from a keypair.
+   *
+   * @param {LDKeyPair} key
+   *
+   * @returns {string} Returns the key's id.
+   */
+  getPublicVerificationMethod({key}) {
+    return (({id, type, controller, publicKeyBase58}) =>
+      ({id, type, controller, publicKeyBase58}))(key);
   }
 };
 

--- a/tests/driver.spec.js
+++ b/tests/driver.spec.js
@@ -79,6 +79,8 @@ describe('did:key method driver', () => {
       const keyId = genDidDoc.authentication[0];
 
       expect(genDidDoc.keys[keyId].controller).to.equal(did);
+      expect(genDidDoc.keypairs.authentication[0].id).to.equal(keyId);
+      expect(genDidDoc.keypairs.authentication[0].controller).to.equal(did);
 
       const fetchedDidDoc = await didKeyDriver.get({did});
 


### PR DESCRIPTION
### Added

- Add `keypairs` property that indexes verification methods.

### Changed
- Avoid mutation of ed25519 key passed into keyToDidDoc.
- Set `id` field for keypairs.

This is being driven by the ezcap work, I'm trying to get to a nice pattern to create the ezcap client:

```js
const baseUrl = 'https://zcap.example/';
const didDocument = await didKeyDriver.generate();
const delegationKeypair = didDocument.keypairs.capabilityDelegation[0];
const invocationKeypair = didDocument.keypairs.capabilityInvocation[0];
zcapClient = new zcapClient({baseUrl, httpsAgent, delegationKeypair, invocationKeypair});
```