### PR TITLE
Refactor implementation of did:key.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 ## 1.0.0 - 2021-01-xx
 
 ### Changed
+- **BREAKING**: Change to named function inputs, `key` -> `keyPair`.
+- **BREAKING**: Rename `computeKeyId()` -> `computeId()`.
+- **BREAKING**: Rename `keyToDidDoc()` -> `keyPairToDidDocument()`.
 - **BREAKING**: Return {didDocument, keyPairs} from `generate()`.
 - Avoid mutation of ed25519 key passed into keyToDidDoc.
 - Set `id` field for keypairs.
+- Use underscores for utility functions.
 
 ## 0.7.0 - 2020-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # did:key driver ChangeLog
 
-## 0.8.0 - 2021-01-22
+## 1.0.0 - 2021-01-xx
 
 ### Changed
 - **BREAKING**: Return {didDocument, keyPairs} from `generate()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # did:key driver ChangeLog
 
-## 0.7.1 - 2021-01-21
-
-### Added
-
-- Add `keypairs` property that indexes verification methods.
+## 0.8.0 - 2021-01-22
 
 ### Changed
+- **BREAKING**: Return {didDocument, keyPairs} from `generate()`.
 - Avoid mutation of ed25519 key passed into keyToDidDoc.
 - Set `id` field for keypairs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **BREAKING**: Rename `computeKeyId()` -> `computeId()`.
 - **BREAKING**: Rename `keyToDidDoc()` -> `keyPairToDidDocument()`.
 - **BREAKING**: Return {didDocument, keyPairs} from `generate()`.
+- Upgrade to crypto-ld 4.0
 - Avoid mutation of ed25519 key passed into keyToDidDoc.
 - Set `id` field for keypairs.
 - Use underscores for utility functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # did:key driver ChangeLog
 
+## 0.7.1 - 2021-01-21
+
+### Added
+
+- Add `keypairs` property that indexes verification methods.
+
+### Changed
+- Avoid mutation of ed25519 key passed into keyToDidDoc.
+- Set `id` field for keypairs.
+
 ## 0.7.0 - 2020-09-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ That DID would correspond to the following DID Document:
 {
   "@context": ["https://w3id.org/did/v0.11"],
   "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
-  "publicKey": [
+  "verificationMethod": [
     {
       "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
       "type": "Ed25519VerificationKey2018",
@@ -115,13 +115,14 @@ To generate a new key and get its corresponding `did:key` method DID Document:
 ```js
 const didKeyDriver = require('did-method-key').driver();
 
-const didDocument = await didKeyDriver.generate(); // Ed25519 key type by default
+// generate did:key using Ed25519 key type by default
+const {didDocument, keyPairs} = await didKeyDriver.generate();
 
-console.log(JSON.stringify(didDocument, null, 2)); // see DID Document above
+// print the DID Document above
+console.log(JSON.stringify(didDocument, null, 2));
 
-didDocument.keys
-// ->
-{
+// keyPairs will be set like so ->
+Map({
   "did:key:z6MkqPnSmWhrV28rjGkGjCuT5Fzxm5WwL6jgAiYc4PvTWVny#z6MkqPnSmWhrV28rjGkGjCuT5Fzxm5WwL6jgAiYc4PvTWVny": {
     "controller": "did:key:z6MkqPnSmWhrV28rjGkGjCuT5Fzxm5WwL6jgAiYc4PvTWVny",
     "type": "Ed25519VerificationKey2018",
@@ -135,13 +136,14 @@ didDocument.keys
     "privateKeyBase58": "BGi7pTP2JHo1odGw3mTWnM4hZmyGWWaAPDne2YHY3VEB",
     "publicKeyBase58": "8bpoQzGLY5ZGfrsQFUrX6Am3eyT3a15haQN8nG1f8eit"
   }
-}
+})
 ```
 
 To get a DID Document for an existing `did:key` DID:
 
 ```js
-const didDocument = await didKeyDriver.get({did: 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH'});
+const did = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+const didDocument = await didKeyDriver.get({did});
 ```
 
 (Results in the [example DID Doc](#example-did-document) above).
@@ -154,8 +156,7 @@ const {Ed25519KeyPair} = require('crypto-ld');
 const {keyToDidDoc} = require('did-method-key').driver();
 
 const edKey = await Ed25519KeyPair.generate();
-
-const didDoc = await keyToDidDoc(edKey);
+const {didDocument, keyPairs} = await keyToDidDoc(edKey);
 
 // Returns a DID Document
 ```

--- a/lib/Driver.js
+++ b/lib/Driver.js
@@ -51,16 +51,16 @@ module.exports = class Driver {
     let promise = this._cache.get(didAuthority);
     if(!promise) {
       const fingerprint = didAuthority.substr('did:key:'.length);
-      const publicKey = LDKeyPair.fromFingerprint({fingerprint});
+      const keyPair = LDKeyPair.fromFingerprint({fingerprint});
 
-      promise = this.keyToDidDoc(publicKey);
+      promise = this.keyPairToDidDocument({keyPair});
       this._cache.set(didAuthority, promise);
       addedToCache = true;
     }
 
-    let didDoc;
+    let didDocument;
     try {
-      ({didDocument: didDoc} = await promise);
+      ({didDocument} = await promise);
     } catch(e) {
       if(addedToCache) {
         this._cache.del(didAuthority);
@@ -70,10 +70,10 @@ module.exports = class Driver {
 
     if(keyIdFragment) {
       // Resolve an individual key
-      return _getKey({didDoc, keyIdFragment});
+      return _getKey({didDocument, keyIdFragment});
     }
     // Resolve the full DID Document
-    return didDoc;
+    return didDocument;
   }
 
   /**
@@ -83,32 +83,33 @@ module.exports = class Driver {
    * @returns {Promise<DidDocument>}
    */
   async generate({keyType = 'Ed25519VerificationKey2018'} = {}) {
-    const publicKey = await LDKeyPair.generate({type: keyType});
-    return this.keyToDidDoc(publicKey);
+    const keyPair = await LDKeyPair.generate({type: keyType});
+    return this.keyPairToDidDocument({keyPair});
   }
 
   /**
    * Converts an Ed25519KeyPair object to a `did:key` method DID Document.
    *
-   * @param {Ed25519KeyPair} ed25519Key
+   * @param {Ed25519KeyPair} keyPair - The key pair to use to generate the
+   *   DID Document.
    * @returns {object} - An object containing the `didDocument` and `keyPairs`.
    */
-  async keyToDidDoc(ed25519Key) {
-    const edKey = new Ed25519KeyPair({
-      publicKeyBase58: ed25519Key.publicKey,
-      privateKeyBase58: ed25519Key.privateKey
+  async keyPairToDidDocument({keyPair} = {}) {
+    const edKeyPair = new Ed25519KeyPair({
+      publicKeyBase58: keyPair.publicKey,
+      privateKeyBase58: keyPair.privateKey
     });
-    const did = `did:key:${edKey.fingerprint()}`;
-    edKey.id = `${did}#${edKey.fingerprint()}`;
-    edKey.controller = did;
+    const did = `did:key:${edKeyPair.fingerprint()}`;
+    edKeyPair.id = `${did}#${edKeyPair.fingerprint()}`;
+    edKeyPair.controller = did;
 
-    const dhKey = await X25519KeyPair.fromEdKeyPair(edKey);
-    dhKey.id = `${did}#${dhKey.fingerprint()}`;
-    dhKey.controller = did;
+    const dhKeyPair = await X25519KeyPair.fromEdKeyPair(edKeyPair);
+    dhKeyPair.id = `${did}#${dhKeyPair.fingerprint()}`;
+    dhKeyPair.controller = did;
 
     // get the public components of each keypair
-    const publicEdKey = _verificationMethodFromKeyPair({keyPair: edKey});
-    const publicDhKey = _verificationMethodFromKeyPair({keyPair: dhKey});
+    const publicEdKey = _verificationMethodFromKeyPair({keyPair: edKeyPair});
+    const publicDhKey = _verificationMethodFromKeyPair({keyPair: dhKeyPair});
 
     // generate the DID Document
     const didDocument = {
@@ -124,21 +125,22 @@ module.exports = class Driver {
 
     // create the key pairs map
     const keyPairs = new Map();
-    keyPairs.set(edKey.id, edKey);
-    keyPairs.set(dhKey.id, dhKey);
+    keyPairs.set(edKeyPair.id, edKeyPair);
+    keyPairs.set(dhKeyPair.id, dhKeyPair);
 
     return {didDocument, keyPairs};
   }
 
   /**
-   * Computes and returns the id of a given key. Used by `did-io` drivers.
+   * Computes and returns the id of a given key pair. Used by `did-io` drivers.
    *
-   * @param {LDKeyPair} key
+   * @param {LDKeyPair} keyPair - the key pair to use when computing the
+   *   identifier.
    *
    * @returns {string} Returns the key's id.
    */
-  async computeKeyId({key}) {
-    return `did:key:${key.fingerprint()}#${key.fingerprint()}`;
+  async computeId({keyPair}) {
+    return `did:key:${keyPair.fingerprint()}#${keyPair.fingerprint()}`;
   }
 };
 
@@ -160,16 +162,17 @@ function _verificationMethodFromKeyPair({keyPair}) {
 /**
  * Returns the public key object for a given key id fragment.
  *
- * @param {DidDocument} didDoc
- * @param {string} keyIdFragment
+ * @param {DidDocument} didDocument - The DID Document to use when generating
+ *   the id.
+ * @param {string} keyIdFragment - The key identifier fragment.
  *
  * @returns {object} public key node, with `@context`
  */
-function _getKey({didDoc, keyIdFragment}) {
+function _getKey({didDocument, keyIdFragment}) {
   // Determine if the key id fragment belongs to the "main" public key,
   // or the keyAgreement key
-  const keyId = didDoc.id + '#' + keyIdFragment;
-  const publicKey = didDoc.verificationMethod[0];
+  const keyId = didDocument.id + '#' + keyIdFragment;
+  const publicKey = didDocument.verificationMethod[0];
 
   if(publicKey.id === keyId) {
     // Return the public key node for the main public key
@@ -181,6 +184,6 @@ function _getKey({didDoc, keyIdFragment}) {
   // Return the public key node for the X25519 key-agreement key
   return {
     '@context': securityConstants.SECURITY_CONTEXT_V2_URL,
-    ...didDoc.keyAgreement[0]
+    ...didDocument.keyAgreement[0]
   };
 }

--- a/lib/Driver.js
+++ b/lib/Driver.js
@@ -60,7 +60,8 @@ module.exports = class Driver {
 
     let didDoc;
     try {
-      didDoc = await promise;
+      const {didDocument} = await promise;
+      didDoc = didDocument;
     } catch(e) {
       if(addedToCache) {
         this._cache.del(didAuthority);
@@ -91,7 +92,7 @@ module.exports = class Driver {
    * Converts an Ed25519KeyPair object to a `did:key` method DID Document.
    *
    * @param {Ed25519KeyPair} ed25519Key
-   * @returns {DidDocument}
+   * @returns {object} - An object containing the `didDocument` and `keypairs`.
    */
   async keyToDidDoc(ed25519Key) {
     const edKey = new Ed25519KeyPair({
@@ -111,10 +112,9 @@ module.exports = class Driver {
     const publicDhKey = this.getPublicVerificationMethod({key: dhKey});
 
     // generate the DID Document
-    const didDoc = {
+    const didDocument = {
       '@context': ['https://w3id.org/did/v0.11'],
       id: did,
-      publicKey: [publicEdKey], // FIXME: publicKey is deprecated, remove
       verificationMethod: [publicEdKey],
       authentication: [publicEdKey.id],
       assertionMethod: [publicEdKey.id],
@@ -122,30 +122,13 @@ module.exports = class Driver {
       capabilityInvocation: [publicEdKey.id],
       keyAgreement: [publicDhKey],
     };
-    // FIXME: 'keys' is misleading as devs might think 'public keys'; remove
-    Object.defineProperty(didDoc, 'keys', {
-      value: {
-        [edKey.id]: edKey,
-        [dhKey.id]: dhKey
-      },
-      enumerable: false
-    });
-    Object.defineProperty(didDoc, 'keypairs', {
-      value: {
-        [edKey.id]: edKey,
-        [dhKey.id]: dhKey,
-        publicKey: [edKey],
-        verificationMethod: [edKey],
-        authentication: [edKey],
-        assertionMethod: [edKey],
-        capabilityDelegation: [edKey],
-        capabilityInvocation: [edKey],
-        keyAgreement: [dhKey],
-      },
-      enumerable: false
-    });
 
-    return didDoc;
+    // create the key pairs map
+    const keyPairs = new Map();
+    keyPairs.set(edKey.id, edKey);
+    keyPairs.set(dhKey.id, dhKey);
+
+    return {didDocument, keyPairs};
   }
 
   /**
@@ -184,7 +167,7 @@ function getKey({didDoc, keyIdFragment}) {
   // Determine if the key id fragment belongs to the "main" public key,
   // or the keyAgreement key
   const keyId = didDoc.id + '#' + keyIdFragment;
-  const publicKey = didDoc.publicKey[0];
+  const publicKey = didDoc.verificationMethod[0];
 
   if(publicKey.id === keyId) {
     // Return the public key node for the main public key

--- a/lib/Driver.js
+++ b/lib/Driver.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-const {LDKeyPair} = require('crypto-ld');
+const {Ed25519KeyPair, LDKeyPair} = require('crypto-ld');
 const {X25519KeyPair} = require('x25519-key-pair');
 const {constants: securityConstants} = require('security-context');
 const LRU = require('lru-cache');
@@ -90,41 +90,57 @@ module.exports = class Driver {
   /**
    * Converts an Ed25519KeyPair object to a `did:key` method DID Document.
    *
-   * @param {Ed25519KeyPair} edKey
+   * @param {Ed25519KeyPair} ed25519Key
    * @returns {DidDocument}
    */
-  async keyToDidDoc(edKey) {
+  async keyToDidDoc(ed25519Key) {
+    const edKey = new Ed25519KeyPair({
+      publicKeyBase58: ed25519Key.publicKey,
+      privateKeyBase58: ed25519Key.privateKey,
+    });
     const did = `did:key:${edKey.fingerprint()}`;
-    const keyId = `${did}#${edKey.fingerprint()}`;
+    edKey.id = `${did}#${edKey.fingerprint()}`;
     edKey.controller = did;
 
     const dhKey = await X25519KeyPair.fromEdKeyPair(edKey);
     dhKey.id = `${did}#${dhKey.fingerprint()}`;
+    dhKey.controller = did;
 
+    // get the public components of each keypair
+    const publicEdKey = this.getPublicVerificationMethod({key: edKey});
+    const publicDhKey = this.getPublicVerificationMethod({key: dhKey});
+
+    // generate the DID Document
     const didDoc = {
       '@context': ['https://w3id.org/did/v0.11'],
       id: did,
-      publicKey: [{
-        id: keyId,
-        type: edKey.type,
-        controller: did,
-        publicKeyBase58: edKey.publicKeyBase58
-      }],
-      authentication: [keyId],
-      assertionMethod: [keyId],
-      capabilityDelegation: [keyId],
-      capabilityInvocation: [keyId],
-      keyAgreement: [{
-        id: dhKey.id,
-        type: dhKey.type,
-        controller: did,
-        publicKeyBase58: dhKey.publicKeyBase58
-      }]
+      publicKey: [publicEdKey], // FIXME: publicKey is deprecated, remove
+      verificationMethod: [publicEdKey],
+      authentication: [publicEdKey.id],
+      assertionMethod: [publicEdKey.id],
+      capabilityDelegation: [publicEdKey.id],
+      capabilityInvocation: [publicEdKey.id],
+      keyAgreement: [publicDhKey],
     };
+    // FIXME: 'keys' is misleading as devs might think 'public keys'; remove
     Object.defineProperty(didDoc, 'keys', {
       value: {
-        [keyId]: edKey,
+        [edKey.id]: edKey,
         [dhKey.id]: dhKey
+      },
+      enumerable: false
+    });
+    Object.defineProperty(didDoc, 'keypairs', {
+      value: {
+        [edKey.id]: edKey,
+        [dhKey.id]: dhKey,
+        publicKey: [edKey],
+        verificationMethod: [edKey],
+        authentication: [edKey],
+        assertionMethod: [edKey],
+        capabilityDelegation: [edKey],
+        capabilityInvocation: [edKey],
+        keyAgreement: [dhKey],
       },
       enumerable: false
     });
@@ -139,8 +155,20 @@ module.exports = class Driver {
    *
    * @returns {string} Returns the key's id.
    */
-  async computeKeyId({key}) {
+  computeKeyId({key}) {
     return `did:key:${key.fingerprint()}#${key.fingerprint()}`;
+  }
+
+  /**
+   * Generates a public verification method from a keypair.
+   *
+   * @param {LDKeyPair} key
+   *
+   * @returns {string} Returns the key's id.
+   */
+  getPublicVerificationMethod({key}) {
+    return (({id, type, controller, publicKeyBase58}) =>
+      ({id, type, controller, publicKeyBase58}))(key);
   }
 };
 

--- a/lib/Driver.js
+++ b/lib/Driver.js
@@ -70,7 +70,7 @@ module.exports = class Driver {
 
     if(keyIdFragment) {
       // Resolve an individual key
-      return getKey({didDoc, keyIdFragment});
+      return _getKey({didDoc, keyIdFragment});
     }
     // Resolve the full DID Document
     return didDoc;
@@ -107,8 +107,8 @@ module.exports = class Driver {
     dhKey.controller = did;
 
     // get the public components of each keypair
-    const publicEdKey = verificationMethodFromKeyPair({keyPair: edKey});
-    const publicDhKey = verificationMethodFromKeyPair({keyPair: dhKey});
+    const publicEdKey = _verificationMethodFromKeyPair({keyPair: edKey});
+    const publicDhKey = _verificationMethodFromKeyPair({keyPair: dhKey});
 
     // generate the DID Document
     const didDocument = {
@@ -151,7 +151,7 @@ module.exports = class Driver {
  *
  * @returns {string} Returns a verification method.
  */
-function verificationMethodFromKeyPair({keyPair}) {
+function _verificationMethodFromKeyPair({keyPair}) {
   const {id, type, controller, publicKeyBase58} = keyPair;
 
   return {id, type, controller, publicKeyBase58};
@@ -165,7 +165,7 @@ function verificationMethodFromKeyPair({keyPair}) {
  *
  * @returns {object} public key node, with `@context`
  */
-function getKey({didDoc, keyIdFragment}) {
+function _getKey({didDoc, keyIdFragment}) {
   // Determine if the key id fragment belongs to the "main" public key,
   // or the keyAgreement key
   const keyId = didDoc.id + '#' + keyIdFragment;

--- a/lib/Driver.js
+++ b/lib/Driver.js
@@ -3,10 +3,15 @@
  */
 'use strict';
 
-const {Ed25519KeyPair, LDKeyPair} = require('crypto-ld');
+const {Ed25519VerificationKey2018} =
+  require('@digitalbazaar/ed25519-verification-key-2018');
+const {CryptoLD} = require('crypto-ld');
 const LruMemoize = require('@digitalbazaar/lru-memoize');
 const {X25519KeyPair} = require('x25519-key-pair');
 const {constants: securityConstants} = require('security-context');
+
+const cryptoLd = new CryptoLD();
+cryptoLd.use(Ed25519VerificationKey2018);
 
 module.exports = class Driver {
   constructor({maxCacheSize = 100, maxCacheAge = 300000} = {}) {
@@ -54,7 +59,8 @@ module.exports = class Driver {
         key: didAuthority,
         fn: () => {
           const fingerprint = didAuthority.substr('did:key:'.length);
-          const keyPair = LDKeyPair.fromFingerprint({fingerprint});
+          const keyPair =
+            Ed25519VerificationKey2018.fromFingerprint({fingerprint});
           return this.keyPairToDidDocument({keyPair});
         }
       });
@@ -79,7 +85,7 @@ module.exports = class Driver {
    * @returns {Promise<DidDocument>}
    */
   async generate({keyType = 'Ed25519VerificationKey2018'} = {}) {
-    const keyPair = await LDKeyPair.generate({type: keyType});
+    const keyPair = await cryptoLd.generate({type: keyType});
     return this.keyPairToDidDocument({keyPair});
   }
 
@@ -91,11 +97,8 @@ module.exports = class Driver {
    * @returns {object} - An object containing the `didDocument` and `keyPairs`.
    */
   async keyPairToDidDocument({keyPair} = {}) {
-    const edKeyPair = new Ed25519KeyPair({
-      publicKeyBase58: keyPair.publicKey,
-      privateKeyBase58: keyPair.privateKey
-    });
-    const did = `did:key:${edKeyPair.fingerprint()}`;
+    const did = `did:key:${keyPair.fingerprint()}`;
+    const edKeyPair = await cryptoLd.from(keyPair);
     edKeyPair.id = `${did}#${edKeyPair.fingerprint()}`;
     edKeyPair.controller = did;
 
@@ -104,8 +107,11 @@ module.exports = class Driver {
     dhKeyPair.controller = did;
 
     // get the public components of each keypair
-    const publicEdKey = _verificationMethodFromKeyPair({keyPair: edKeyPair});
-    const publicDhKey = _verificationMethodFromKeyPair({keyPair: dhKeyPair});
+    const publicEdKey = await edKeyPair.export({publicKey: true});
+    const publicDhKey = await dhKeyPair.export({publicKey: true});
+
+    // FIXME: remove private key accidentally exported to public key
+    delete publicDhKey.privateKeyBase58;
 
     // generate the DID Document
     const didDocument = {
@@ -139,21 +145,6 @@ module.exports = class Driver {
     return `did:key:${keyPair.fingerprint()}#${keyPair.fingerprint()}`;
   }
 };
-
-/**
- * Generates a Linked Data verification method from a keypair that does not
- * contain any private data from the key pair.
- *
- * @param {LDKeyPair} keyPair - the keyPair to derive the verification method
- *   from.
- *
- * @returns {string} Returns a verification method.
- */
-function _verificationMethodFromKeyPair({keyPair}) {
-  const {id, type, controller, publicKeyBase58} = keyPair;
-
-  return {id, type, controller, publicKeyBase58};
-}
 
 /**
  * Returns the public key object for a given key id fragment.

--- a/lib/Driver.js
+++ b/lib/Driver.js
@@ -4,15 +4,17 @@
 'use strict';
 
 const {Ed25519KeyPair, LDKeyPair} = require('crypto-ld');
+const LruMemoize = require('@digitalbazaar/lru-memoize');
 const {X25519KeyPair} = require('x25519-key-pair');
 const {constants: securityConstants} = require('security-context');
-const LRU = require('lru-cache');
 
 module.exports = class Driver {
-  constructor({maxCacheSize = 100} = {}) {
+  constructor({maxCacheSize = 100, maxCacheAge = 300000} = {}) {
     // used by did-io to register drivers
     this.method = 'key';
-    this._cache = new LRU({max: maxCacheSize});
+    this._cache = new LruMemoize.default.LruMemoize({
+      max: maxCacheSize, maxAge: maxCacheAge
+    });
   }
 
   /**
@@ -46,34 +48,28 @@ module.exports = class Driver {
     }
 
     const [didAuthority, keyIdFragment] = did.split('#');
-
-    let addedToCache = false;
-    let promise = this._cache.get(didAuthority);
-    if(!promise) {
-      const fingerprint = didAuthority.substr('did:key:'.length);
-      const keyPair = LDKeyPair.fromFingerprint({fingerprint});
-
-      promise = this.keyPairToDidDocument({keyPair});
-      this._cache.set(didAuthority, promise);
-      addedToCache = true;
-    }
-
-    let didDocument;
     try {
-      ({didDocument} = await promise);
-    } catch(e) {
-      if(addedToCache) {
-        this._cache.del(didAuthority);
+      // cache the result of expansion
+      const {didDocument} = await this._cache.memoize({
+        key: didAuthority,
+        fn: () => {
+          const fingerprint = didAuthority.substr('did:key:'.length);
+          const keyPair = LDKeyPair.fromFingerprint({fingerprint});
+          return this.keyPairToDidDocument({keyPair});
+        }
+      });
+
+      if(keyIdFragment) {
+        // Resolve an individual key
+        return _getKey({didDocument, keyIdFragment});
       }
+
+      // Resolve the full DID Document
+      return didDocument;
+    } catch(e) {
+      this._cache.delete(didAuthority);
       throw e;
     }
-
-    if(keyIdFragment) {
-      // Resolve an individual key
-      return _getKey({didDocument, keyIdFragment});
-    }
-    // Resolve the full DID Document
-    return didDocument;
   }
 
   /**

--- a/lib/Driver.js
+++ b/lib/Driver.js
@@ -106,9 +106,9 @@ module.exports = class Driver {
     dhKey.id = `${did}#${dhKey.fingerprint()}`;
     dhKey.controller = did;
 
-    // get the public components of each key pair
-    const publicEdKey = this.getPublicVerificationMethod({key: edKey});
-    const publicDhKey = this.getPublicVerificationMethod({key: dhKey});
+    // get the public components of each keypair
+    const publicEdKey = verificationMethodFromKeyPair({keyPair: edKey});
+    const publicDhKey = verificationMethodFromKeyPair({keyPair: dhKey});
 
     // generate the DID Document
     const didDocument = {
@@ -137,22 +137,25 @@ module.exports = class Driver {
    *
    * @returns {string} Returns the key's id.
    */
-  computeKeyId({key}) {
+  async computeKeyId({key}) {
     return `did:key:${key.fingerprint()}#${key.fingerprint()}`;
   }
-
-  /**
-   * Generates a public verification method from a keypair.
-   *
-   * @param {LDKeyPair} key
-   *
-   * @returns {string} Returns the key's id.
-   */
-  getPublicVerificationMethod({key} = {}) {
-    return (({id, type, controller, publicKeyBase58}) =>
-      ({id, type, controller, publicKeyBase58}))(key);
-  }
 };
+
+/**
+ * Generates a Linked Data verification method from a keypair that does not
+ * contain any private data from the key pair.
+ *
+ * @param {LDKeyPair} keyPair - the keyPair to derive the verification method
+ *   from.
+ *
+ * @returns {string} Returns a verification method.
+ */
+function verificationMethodFromKeyPair({keyPair}) {
+  const {id, type, controller, publicKeyBase58} = keyPair;
+
+  return {id, type, controller, publicKeyBase58};
+}
 
 /**
  * Returns the public key object for a given key id fragment.

--- a/lib/Driver.js
+++ b/lib/Driver.js
@@ -60,8 +60,7 @@ module.exports = class Driver {
 
     let didDoc;
     try {
-      const {didDocument} = await promise;
-      didDoc = didDocument;
+      ({didDocument: didDoc} = await promise);
     } catch(e) {
       if(addedToCache) {
         this._cache.del(didAuthority);
@@ -92,12 +91,12 @@ module.exports = class Driver {
    * Converts an Ed25519KeyPair object to a `did:key` method DID Document.
    *
    * @param {Ed25519KeyPair} ed25519Key
-   * @returns {object} - An object containing the `didDocument` and `keypairs`.
+   * @returns {object} - An object containing the `didDocument` and `keyPairs`.
    */
   async keyToDidDoc(ed25519Key) {
     const edKey = new Ed25519KeyPair({
       publicKeyBase58: ed25519Key.publicKey,
-      privateKeyBase58: ed25519Key.privateKey,
+      privateKeyBase58: ed25519Key.privateKey
     });
     const did = `did:key:${edKey.fingerprint()}`;
     edKey.id = `${did}#${edKey.fingerprint()}`;
@@ -107,7 +106,7 @@ module.exports = class Driver {
     dhKey.id = `${did}#${dhKey.fingerprint()}`;
     dhKey.controller = did;
 
-    // get the public components of each keypair
+    // get the public components of each key pair
     const publicEdKey = this.getPublicVerificationMethod({key: edKey});
     const publicDhKey = this.getPublicVerificationMethod({key: dhKey});
 
@@ -120,7 +119,7 @@ module.exports = class Driver {
       assertionMethod: [publicEdKey.id],
       capabilityDelegation: [publicEdKey.id],
       capabilityInvocation: [publicEdKey.id],
-      keyAgreement: [publicDhKey],
+      keyAgreement: [publicDhKey]
     };
 
     // create the key pairs map
@@ -149,7 +148,7 @@ module.exports = class Driver {
    *
    * @returns {string} Returns the key's id.
    */
-  getPublicVerificationMethod({key}) {
+  getPublicVerificationMethod({key} = {}) {
     return (({id, type, controller, publicKeyBase58}) =>
       ({id, type, controller, publicKeyBase58}))(key);
   }

--- a/lib/Driver.js
+++ b/lib/Driver.js
@@ -6,7 +6,7 @@
 const {Ed25519VerificationKey2018} =
   require('@digitalbazaar/ed25519-verification-key-2018');
 const {CryptoLD} = require('crypto-ld');
-const LruMemoize = require('@digitalbazaar/lru-memoize');
+const {default: {LruMemoize}} = require('@digitalbazaar/lru-memoize');
 const {X25519KeyPair} = require('x25519-key-pair');
 const {constants: securityConstants} = require('security-context');
 
@@ -14,11 +14,11 @@ const cryptoLd = new CryptoLD();
 cryptoLd.use(Ed25519VerificationKey2018);
 
 module.exports = class Driver {
-  constructor({maxCacheSize = 100, maxCacheAge = 300000} = {}) {
+  constructor({maxCacheSize = 100} = {}) {
     // used by did-io to register drivers
     this.method = 'key';
-    this._cache = new LruMemoize.default.LruMemoize({
-      max: maxCacheSize, maxAge: maxCacheAge
+    this._cache = new LruMemoize({
+      max: maxCacheSize
     });
   }
 
@@ -66,14 +66,13 @@ module.exports = class Driver {
       });
 
       if(keyIdFragment) {
-        // Resolve an individual key
+        // resolve an individual key
         return _getKey({didDocument, keyIdFragment});
       }
 
       // Resolve the full DID Document
       return didDocument;
     } catch(e) {
-      this._cache.delete(didAuthority);
       throw e;
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   "license": "BSD-3-Clause",
   "main": "lib/",
   "dependencies": {
+    "@digitalbazaar/ed25519-verification-key-2018": "^1.1.0",
     "@digitalbazaar/lru-memoize": "^1.1.0",
-    "crypto-ld": "^3.7.0",
+    "crypto-ld": "^4.0.3",
     "security-context": "^4.0.0",
-    "x25519-key-pair": "^3.0.0"
+    "x25519-key-pair": "^3.1.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "did-method-key",
-  "version": "0.7.1-0",
+  "version": "0.8.0-0",
   "description": "A did:key method driver for did-io and standalone use.",
   "homepage": "http://github.com/digitalbazaar/did-method-key-js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "nyc": "^15.0.1"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=12.13.0"
   },
   "keywords": [
     "Decentralized",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "did-method-key",
-  "version": "0.8.0-0",
+  "version": "1.0.0-0",
   "description": "A did:key method driver for did-io and standalone use.",
   "homepage": "http://github.com/digitalbazaar/did-method-key-js",
   "author": {
@@ -19,8 +19,8 @@
   "license": "BSD-3-Clause",
   "main": "lib/",
   "dependencies": {
+    "@digitalbazaar/lru-memoize": "^1.1.0",
     "crypto-ld": "^3.7.0",
-    "lru-cache": "^6.0.0",
     "security-context": "^4.0.0",
     "x25519-key-pair": "^3.0.0"
   },

--- a/tests/driver.spec.js
+++ b/tests/driver.spec.js
@@ -79,6 +79,8 @@ describe('did:key method driver', () => {
       const keyId = genDidDoc.authentication[0];
 
       expect(genDidDoc.keys[keyId].controller).to.equal(did);
+      expect(genDidDoc.keypairs.authentication[0].id).to.equal(keyId);
+      expect(genDidDoc.keypairs.authentication[0].controller).to.equal(did);
 
       const fetchedDidDoc = await didKeyDriver.get({did});
 

--- a/tests/driver.spec.js
+++ b/tests/driver.spec.js
@@ -15,23 +15,23 @@ describe('did:key method driver', () => {
       const did = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
       // eslint-disable-next-line max-len
       const keyId = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
-      const didDoc = await didKeyDriver.get({did});
+      const didDocument = await didKeyDriver.get({did});
 
-      expect(didDoc.id).to.equal(did);
-      expect(didDoc['@context']).to.eql(['https://w3id.org/did/v0.11']);
-      expect(didDoc.authentication).to.eql([keyId]);
-      expect(didDoc.assertionMethod).to.eql([keyId]);
-      expect(didDoc.capabilityDelegation).to.eql([keyId]);
-      expect(didDoc.capabilityInvocation).to.eql([keyId]);
+      expect(didDocument.id).to.equal(did);
+      expect(didDocument['@context']).to.eql(['https://w3id.org/did/v0.11']);
+      expect(didDocument.authentication).to.eql([keyId]);
+      expect(didDocument.assertionMethod).to.eql([keyId]);
+      expect(didDocument.capabilityDelegation).to.eql([keyId]);
+      expect(didDocument.capabilityInvocation).to.eql([keyId]);
 
-      const [publicKey] = didDoc.publicKey;
+      const [publicKey] = didDocument.verificationMethod;
       expect(publicKey.id).to.equal(keyId);
       expect(publicKey.type).to.equal('Ed25519VerificationKey2018');
       expect(publicKey.controller).to.equal(did);
       expect(publicKey.publicKeyBase58).to
         .equal('B12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u');
 
-      const [kak] = didDoc.keyAgreement;
+      const [kak] = didDocument.keyAgreement;
       expect(kak.id).to.equal(did +
         '#z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc');
       expect(kak.type).to.equal('X25519KeyAgreementKey2019');
@@ -74,17 +74,15 @@ describe('did:key method driver', () => {
 
   describe('generate', async () => {
     it('should generate and get round trip', async () => {
-      const genDidDoc = await didKeyDriver.generate();
-      const did = genDidDoc.id;
-      const keyId = genDidDoc.authentication[0];
+      const {didDocument, keyPairs} = await didKeyDriver.generate();
+      const did = didDocument.id;
+      const keyId = didDocument.authentication[0];
 
-      expect(genDidDoc.keys[keyId].controller).to.equal(did);
-      expect(genDidDoc.keypairs.authentication[0].id).to.equal(keyId);
-      expect(genDidDoc.keypairs.authentication[0].controller).to.equal(did);
+      expect(keyPairs.get(keyId).controller).to.equal(did);
+      expect(keyPairs.get(keyId).id).to.equal(keyId);
 
       const fetchedDidDoc = await didKeyDriver.get({did});
-
-      expect(fetchedDidDoc).to.eql(genDidDoc);
+      expect(fetchedDidDoc).to.eql(didDocument);
     });
   });
 

--- a/tests/driver.spec.js
+++ b/tests/driver.spec.js
@@ -86,15 +86,13 @@ describe('did:key method driver', () => {
     });
   });
 
-  describe('computeKeyId', async () => {
-    const key = {
-      fingerprint: () => '12345'
-    };
+  describe('computeId', async () => {
+    const keyPair = {fingerprint: () => '12345'};
 
     it('should set the key id based on fingerprint', async () => {
-      key.id = await didKeyDriver.computeKeyId({key});
+      keyPair.id = await didKeyDriver.computeId({keyPair});
 
-      expect(key.id).to.equal('did:key:12345#12345');
+      expect(keyPair.id).to.equal('did:key:12345#12345');
     });
   });
 


### PR DESCRIPTION
### Changed
- **BREAKING**: Change to named function inputs, `key` -> `keyPair`.
- **BREAKING**: Rename `computeKeyId()` -> `computeId()`.
- **BREAKING**: Rename `keyToDidDoc()` -> `keyPairToDidDocument()`.
- **BREAKING**: Return {didDocument, keyPairs} from `generate()`.
- Upgrade to crypto-ld 4.0
- Avoid mutation of ed25519 key passed into keyToDidDoc.
- Set `id` field for keypairs.
- Use underscores for utility functions.

This is being driven by the ezcap work, I'm trying to get to a nice pattern to create the ezcap client:

```js
const baseUrl = 'https://zcap.example/';
const {didDocument, keyPairs} = await didKeyDriver.generate();
const {invocationSigner, delegationSigner} = getCapabilitySigners({didDocument, keyPairs});
const zcapClient = new ZcapClient({baseUrl, invocationSigner, delegationSigner});
```