### PR TITLE
Add methodFor convenience function to generate() return.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,31 +52,35 @@ That DID would correspond to the following DID Document:
     "https://www.w3.org/ns/did/v1",
     "https://w3id.org/security/suites/ed25519-2020/v1"
   ],
-  "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
-  "verificationMethod": [{
-    "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
-    "type": "Ed25519VerificationKey2020",
-    "controller": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
-    "publicKeyMultibase": "zB12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u"
-    }],
+  "id": "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop",
+  "verificationMethod": [
+    {
+      "id": "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop#z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop",
+      "type": "Ed25519VerificationKey2020",
+      "controller": "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop",
+      "publicKeyMultibase": "zrS3jcoWtFYvEmdjKkYeXQqgzvTR3FwU3VTyL7gX2Z2S"
+    }
+  ],
   "authentication": [
-    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+    "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop#z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop"
   ],
   "assertionMethod": [
-    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+    "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop#z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop"
   ],
   "capabilityDelegation": [
-    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+    "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop#z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop"
   ],
   "capabilityInvocation": [
-    "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+    "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop#z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop"
   ],
-  "keyAgreement": [{
-    "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH#z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
-    "type": "X25519KeyAgreementKey2019",
-    "controller": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
-    "publicKeyBase58": "JhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr"
-  }]
+  "keyAgreement": [
+    {
+      "id": "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop#z6LSmNXTNXTkUPL6UHaBCDJhtvNTTzCgcUQ6kM6S7zngPFPj",
+      "type": "X25519KeyAgreementKey2019",
+      "controller": "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop",
+      "publicKeyBase58": "AhMHrDetNvcMNuCQfZnkaL9ycqfZusDwsNNkdY99fscy"
+    }
+  ]
 }
 ```
 
@@ -117,38 +121,57 @@ const didKeyDriver = require('@digitalbazaar/did-method-key').driver();
 
 // generate did:key using Ed25519 key type by default
 const {
-  didDocument, keyPairs, verificationKeyPair, keyAgreementKeyPair
+  didDocument, keyPairs
 } = await didKeyDriver.generate();
 
 // print the DID Document above
 console.log(JSON.stringify(didDocument, null, 2));
 
 // keyPairs will be set like so ->
-Map({
-  "did:key:z6MkqPnSmWhrV28rjGkGjCuT5Fzxm5WwL6jgAiYc4PvTWVny#z6MkqPnSmWhrV28rjGkGjCuT5Fzxm5WwL6jgAiYc4PvTWVny": {
-    "controller": "did:key:z6MkqPnSmWhrV28rjGkGjCuT5Fzxm5WwL6jgAiYc4PvTWVny",
-    "type": "Ed25519VerificationKey2018",
-    "privateKeyBase58": "3rACVtG71pbij7fvVenidrMjk9jDDMeBG7LeUt84cbyC5BCcAgyrpaDzGHAn38snSXbGKkNhaRKVMvSyt4bpAxgy",
-    "publicKeyBase58": "BwXQBGTR9UePcmua3dwcEASxwWF5vDVKUhdgE7xSbH1b"
-  },
-  "did:key:z6MkqPnSmWhrV28rjGkGjCuT5Fzxm5WwL6jgAiYc4PvTWVny#z6LSjGzxwJ5CdYH1mFFAn8NUQkyXW7zAGcFrTP5pGifBr2Ve": {
-    "id": "did:key:z6MkqPnSmWhrV28rjGkGjCuT5Fzxm5WwL6jgAiYc4PvTWVny#z6LSjGzxwJ5CdYH1mFFAn8NUQkyXW7zAGcFrTP5pGifBr2Ve",
-    "controller": "did:key:z6MkqPnSmWhrV28rjGkGjCuT5Fzxm5WwL6jgAiYc4PvTWVny",
-    "type": "X25519KeyAgreementKey2019",
-    "privateKeyBase58": "BGi7pTP2JHo1odGw3mTWnM4hZmyGWWaAPDne2YHY3VEB",
-    "publicKeyBase58": "8bpoQzGLY5ZGfrsQFUrX6Am3eyT3a15haQN8nG1f8eit"
-  }
-})
+Map(
+    {
+      "id": "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop#z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop",
+      "type": "Ed25519VerificationKey2020",
+      "controller": "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop",
+      "publicKeyMultibase": "zrS3jcoWtFYvEmdjKkYeXQqgzvTR3FwU3VTyL7gX2Z2S",
+      "privateKeyMultibase": "zAikBWSMGw5qsBZ5oz99dZhLUyheEamiKyeyJCMnchnFn1zXapmditR7NY317ajE5KrxGp7FpakADViDFeWhm8C2"
+    },
+    {
+      "id": "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop#z6LSmNXTNXTkUPL6UHaBCDJhtvNTTzCgcUQ6kM6S7zngPFPj",
+      "type": "X25519KeyAgreementKey2019",
+      "controller": "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop",
+      "publicKeyBase58": "AhMHrDetNvcMNuCQfZnkaL9ycqfZusDwsNNkdY99fscy",
+      "privateKeyBase58": "HBxPbDj1ZteHV1t63bwwvEFsssG6u7pGzVEPsHMFyhGz"
+    }
+);
 ```
 
 To get a DID Document for an existing `did:key` DID:
 
 ```js
-const did = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+const did = 'did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop';
 const didDocument = await didKeyDriver.get({did});
 ```
 
 (Results in the [example DID Doc](#example-did-document) above).
+
+You can also use a `.get()` to retrieve an individual key (this is useful
+for constructing `documentLoader`s for JSON-LD Signature libs, and the resulting
+key does include the appropriate `@context`).
+
+```js
+
+const verificationKeyId = 'did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop#z6LSmNXTNXTkUPL6UHaBCDJhtvNTTzCgcUQ6kM6S7zngPFPj';
+await didKeyDriver.get({url: verificationKeyId});
+// ->
+{
+  "@context": "https://w3id.org/security/v2",
+  "id": "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop#z6LSmNXTNXTkUPL6UHaBCDJhtvNTTzCgcUQ6kM6S7zngPFPj",
+  "type": "X25519KeyAgreementKey2019",
+  "controller": "did:key:z6MkfJh6Ks3xDo3PMGUS1KWVNWPgpVjGT9BpjWNuAPeXwmop",
+  "publicKeyBase58": "AhMHrDetNvcMNuCQfZnkaL9ycqfZusDwsNNkdY99fscy"
+}
+```
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ npm install
 
 ## Usage
 
+### `generate()`
+
 To generate a new key and get its corresponding `did:key` method DID Document:
 
 ```js
@@ -121,7 +123,7 @@ const didKeyDriver = require('@digitalbazaar/did-method-key').driver();
 
 // generate did:key using Ed25519 key type by default
 const {
-  didDocument, keyPairs
+  didDocument, keyPairs, methodFor
 } = await didKeyDriver.generate();
 
 // print the DID Document above
@@ -145,6 +147,24 @@ Map(
     }
 );
 ```
+
+`methodFor` is a convenience function that returns a key pair instance for a 
+given purpose. For example, a verification key (containing a `signer()` and 
+`verifier()` functions) are frequently useful for 
+[`jsonld-signatures`](https://github.com/digitalbazaar/jsonld-signatures) or
+[`vc-js`](https://github.com/digitalbazaar/vc-js) operations. After generating
+a new did:key DID, you can do:
+
+```js
+// For signing Verifiable Credentials
+const verificationKeyPair = methodFor({purpose: 'assertionMethod'});
+// For Authorization Capabilities (zCaps)
+const invocationKeyPair = methodFor({purpose: 'capabilityInvocation'});
+// For Encryption using `@digitalbazaar/minimal-cipher`
+const keyAgreementPair = methodFor({purpose: 'keyAgreement'});
+```
+
+### `get()`
 
 To get a DID Document for an existing `did:key` DID:
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ a new did:key DID, you can do:
 
 ```js
 // For signing Verifiable Credentials
-const verificationKeyPair = methodFor({purpose: 'assertionMethod'});
+const assertionKeyPair = methodFor({purpose: 'assertionMethod'});
 // For Authorization Capabilities (zCaps)
 const invocationKeyPair = methodFor({purpose: 'capabilityInvocation'});
 // For Encryption using `@digitalbazaar/minimal-cipher`

--- a/lib/DidKeyDriver.js
+++ b/lib/DidKeyDriver.js
@@ -9,6 +9,7 @@ import {
 } from '@digitalbazaar/x25519-key-agreement-key-2019';
 
 import didContext from 'did-context';
+import {findVerificationMethod} from '@digitalbazaar/did-io';
 import ed25519Context from 'ed25519-signature-2020-context';
 import securityContext from 'security-context';
 
@@ -41,14 +42,27 @@ export class DidKeyDriver {
    *   deterministic key.
    *
    * @returns {Promise<{didDocument: object, keyPairs: Map,
-   *   verificationKeyPair: LDKeyPair, keyAgreementKeyPair: LDKeyPair}>}
-   *   Resolves with the generated DID Document, along with the corresponding
-   *   key pairs used to generate it (for storage in a KMS).
+   *   methodFor: Function}>} Resolves with the generated DID Document, along
+   *   with the corresponding key pairs used to generate it (for storage in a
+   *   KMS).
    */
   async generate({seed} = {}) {
     const verificationKeyPair = await this.verificationSuite.generate({seed});
 
-    return this._keyPairToDidDocument({keyPair: verificationKeyPair});
+    const {didDocument, keyPairs} = await this._keyPairToDidDocument({
+      keyPair: verificationKeyPair
+    });
+
+    // Convenience function that returns the key pair instance for a given
+    // purpose (authentication, assertionMethod, etc).
+    const methodFor = ({purpose}) => {
+      const {id: methodId} = findVerificationMethod({
+        doc: didDocument, purpose
+      });
+      return keyPairs.get(methodId);
+    };
+
+    return {didDocument, keyPairs, methodFor};
   }
 
   /**
@@ -99,8 +113,7 @@ export class DidKeyDriver {
    * @param {LDKeyPair} options.keyPair - A verification key pair to use to
    *   generate the DID Document.
    *
-   * @returns {Promise<{didDocument: object, keyPairs: Map,
-   *   verificationKeyPair: LDKeyPair, keyAgreementKeyPair: LDKeyPair}>}
+   * @returns {Promise<{didDocument: object, keyPairs: Map}>}
    *   Resolves with the generated DID Document, along with the corresponding
    *   key pairs used to generate it (for storage in a KMS).
    */
@@ -140,7 +153,7 @@ export class DidKeyDriver {
     keyPairs.set(verificationKeyPair.id, verificationKeyPair);
     keyPairs.set(keyAgreementKeyPair.id, keyAgreementKeyPair);
 
-    return {didDocument, keyPairs, verificationKeyPair, keyAgreementKeyPair};
+    return {didDocument, keyPairs};
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "main": "lib/index.js",
   "module": "lib/main.js",
   "dependencies": {
+    "@digitalbazaar/did-io": "digitalbazaar/did-io#v0.9.x",
     "@digitalbazaar/ed25519-verification-key-2020": "^2.0.0",
     "@digitalbazaar/x25519-key-agreement-key-2019": "^5.0.1",
     "did-context": "digitalbazaar/did-context#did-core-cr",

--- a/test/driver.spec.js
+++ b/test/driver.spec.js
@@ -78,10 +78,13 @@ describe('did:key method driver', () => {
   describe('generate', async () => {
     it('should generate and get round trip', async () => {
       const {
-        didDocument, keyPairs, verificationKeyPair, keyAgreementKeyPair
+        didDocument, keyPairs, methodFor
       } = await didKeyDriver.generate();
       const did = didDocument.id;
       const keyId = didDocument.authentication[0];
+
+      const verificationKeyPair = methodFor({purpose: 'assertionMethod'});
+      const keyAgreementKeyPair = methodFor({purpose: 'keyAgreement'});
 
       expect(keyId).to.equal(verificationKeyPair.id);
       expect(keyAgreementKeyPair.type).to.equal('X25519KeyAgreementKey2019');


### PR DESCRIPTION
Adds a `methodFor` convenience function (as a replacement for the did:key-specific `verificationKeyPair` and `keyAgreementKeyPair` return properties), based on conversation with @mattcollier and @dlongley.

Usage:

```js
const {didDocument, keyPairs, methodFor} = await didKeyDriver.generate();

// For signing Verifiable Credentials
const verificationKeyPair = methodFor({purpose: 'assertionMethod'});
// For Authorization Capabilities (zCaps)
const invocationKeyPair = methodFor({purpose: 'capabilityInvocation'});
// For Encryption using `@digitalbazaar/minimal-cipher`
const keyAgreementPair = methodFor({purpose: 'keyAgreement'});
```