### PR TITLE
Implement a publicMethodFor() helper function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ const assertionMethodPublicKey = await cryptoLd.from(assertionMethodData);
 const {verify} = assertionMethodPublicKey.verifier();
 ```
 
+`publicMethodFor` will return `undefined` if no key is found for a given
+purpose.
+
 ## Contribute
 
 See [the contribute file](https://github.com/digitalbazaar/bedrock/blob/master/CONTRIBUTING.md)!

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,7 +33,8 @@ module.exports = function(config) {
       resolve: {
         fallback: {
           url: false,
-          crypto: false
+          crypto: false,
+          global: false
         }
       }
     },

--- a/lib/DidKeyDriver.js
+++ b/lib/DidKeyDriver.js
@@ -92,7 +92,11 @@ export class DidKeyDriver {
       throw new TypeError('The "purpose" parameter is required.');
     }
 
-    return didIo.findVerificationMethod({doc: didDocument, purpose});
+    const method = didIo.findVerificationMethod({doc: didDocument, purpose});
+    if(!method) {
+      throw new Error(`No verification method found for purpose "${purpose}"`);
+    }
+    return method;
   }
 
   /**

--- a/lib/DidKeyDriver.js
+++ b/lib/DidKeyDriver.js
@@ -84,6 +84,9 @@ export class DidKeyDriver {
    *   Document), without a `@context`.
    */
   publicMethodFor({didDocument, purpose} = {}) {
+    if(!didDocument) {
+      throw new TypeError('The "didDocument" parameter is required.');
+    }
     if(!purpose) {
       throw new TypeError('The "purpose" parameter is required.');
     }

--- a/lib/DidKeyDriver.js
+++ b/lib/DidKeyDriver.js
@@ -81,8 +81,7 @@ export class DidKeyDriver {
    *   'authentication', 'assertionMethod', 'keyAgreement' and so on.
    *
    * @returns {object} Returns the public key object (obtained from the DID
-   *   Document), without a `@context`. Returns undefined if no key is found
-   *   for that purpose.
+   *   Document), without a `@context`.
    */
   publicMethodFor({didDocument, purpose} = {}) {
     if(!didDocument) {

--- a/lib/DidKeyDriver.js
+++ b/lib/DidKeyDriver.js
@@ -81,7 +81,8 @@ export class DidKeyDriver {
    *   'authentication', 'assertionMethod', 'keyAgreement' and so on.
    *
    * @returns {object} Returns the public key object (obtained from the DID
-   *   Document), without a `@context`.
+   *   Document), without a `@context`. Returns undefined if no key is found
+   *   for that purpose.
    */
   publicMethodFor({didDocument, purpose} = {}) {
     if(!didDocument) {

--- a/lib/DidKeyDriver.js
+++ b/lib/DidKeyDriver.js
@@ -9,7 +9,7 @@ import {
 } from '@digitalbazaar/x25519-key-agreement-key-2020';
 
 import didContext from 'did-context';
-import {findVerificationMethod} from '@digitalbazaar/did-io';
+import * as didIo from '@digitalbazaar/did-io';
 import ed25519Context from 'ed25519-signature-2020-context';
 import x25519Context from 'x25519-key-agreement-2020-context';
 
@@ -52,13 +52,43 @@ export class DidKeyDriver {
     // Convenience function that returns the public/private key pair instance
     // for a given purpose (authentication, assertionMethod, keyAgreement, etc).
     const methodFor = ({purpose}) => {
-      const {id: methodId} = findVerificationMethod({
+      const {id: methodId} = didIo.findVerificationMethod({
         doc: didDocument, purpose
       });
       return keyPairs.get(methodId);
     };
 
     return {didDocument, keyPairs, methodFor};
+  }
+
+  /**
+   * Returns the public key (verification method) object for a given DID
+   * Document and purpose. Useful in conjunction with a `.get()` call.
+   *
+   * @example
+   * const didDocument = await didKeyDriver.get({did});
+   * const authKeyData = didDriver.publicMethodFor({
+   *   didDocument, purpose: 'authentication'
+   * });
+   * // You can then create a suite instance object to verify signatures etc.
+   * const authPublicKey = await cryptoLd.from(authKeyData);
+   * const {verify} = authPublicKey.verifier();
+   *
+   * @param {object} options - Options hashmap.
+   * @param {object} options.didDocument - DID Document (retrieved via a
+   *   `.get()` or from some other source).
+   * @param {string} options.purpose - Verification method purpose, such as
+   *   'authentication', 'assertionMethod', 'keyAgreement' and so on.
+   *
+   * @returns {object} Returns the public key object (obtained from the DID
+   *   Document), without a `@context`.
+   */
+  publicMethodFor({didDocument, purpose} = {}) {
+    if(!purpose) {
+      throw new TypeError('The "purpose" parameter is required.');
+    }
+
+    return didIo.findVerificationMethod({doc: didDocument, purpose});
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "module": "lib/main.js",
   "dependencies": {
     "@digitalbazaar/did-io": "^1.0.0",
-    "@digitalbazaar/ed25519-verification-key-2020": "^2.0.0",
+    "@digitalbazaar/ed25519-verification-key-2020": "^2.1.1",
     "@digitalbazaar/x25519-key-agreement-key-2020": "^1.0.0",
     "did-context": "^3.0.0",
     "ed25519-signature-2020-context": "^1.0.1",

--- a/test/driver.spec.js
+++ b/test/driver.spec.js
@@ -122,6 +122,17 @@ describe('did:key method driver', () => {
         .property('publicKeyMultibase',
           'zB12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u');
     });
+
+    it('should return undefined if key is not found for purpose', async () => {
+      const did = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+      // First, get the did document
+      const didDocument = await didKeyDriver.get({did});
+      // Then publicMethodFor can be used to fetch key data
+      const result = didKeyDriver.publicMethodFor({
+        didDocument, purpose: 'invalidPurpose'
+      });
+      expect(result).to.be.undefined;
+    });
   });
 
   describe('computeId', () => {

--- a/test/driver.spec.js
+++ b/test/driver.spec.js
@@ -76,7 +76,7 @@ describe('did:key method driver', () => {
     });
   });
 
-  describe('generate', async () => {
+  describe('generate', () => {
     it('should generate and get round trip', async () => {
       const {
         didDocument, keyPairs, methodFor
@@ -98,7 +98,33 @@ describe('did:key method driver', () => {
     });
   });
 
-  describe('computeId', async () => {
+  describe('publicMethodFor', () => {
+    it('should find a key for a did doc and purpose', async () => {
+      const did = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
+      // First, get the did document
+      const didDocument = await didKeyDriver.get({did});
+      // Then publicMethodFor can be used to fetch key data
+      const keyAgreementData = didKeyDriver.publicMethodFor({
+        didDocument, purpose: 'keyAgreement'
+      });
+      expect(keyAgreementData).to.have
+        .property('type', 'X25519KeyAgreementKey2020');
+      expect(keyAgreementData).to.have
+        .property('publicKeyMultibase',
+          'zJhNWeSVLMYccCk7iopQW4guaSJTojqpMEELgSLhKwRr');
+
+      const authKeyData = didKeyDriver.publicMethodFor({
+        didDocument, purpose: 'authentication'
+      });
+      expect(authKeyData).to.have
+        .property('type', 'Ed25519VerificationKey2020');
+      expect(authKeyData).to.have
+        .property('publicKeyMultibase',
+          'zB12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u');
+    });
+  });
+
+  describe('computeId', () => {
     const keyPair = {fingerprint: () => '12345'};
 
     it('should set the key id based on fingerprint', async () => {

--- a/test/driver.spec.js
+++ b/test/driver.spec.js
@@ -123,15 +123,23 @@ describe('did:key method driver', () => {
           'zB12NYF8RrR3h41TDCTJojY59usg3mbtbjnFs7Eud1Y6u');
     });
 
-    it('should return undefined if key is not found for purpose', async () => {
+    it('should throw error if key is not found for purpose', async () => {
       const did = 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH';
       // First, get the did document
       const didDocument = await didKeyDriver.get({did});
-      // Then publicMethodFor can be used to fetch key data
-      const result = didKeyDriver.publicMethodFor({
-        didDocument, purpose: 'invalidPurpose'
-      });
-      expect(result).to.be.undefined;
+
+      let error;
+      try {
+        didKeyDriver.publicMethodFor({
+          didDocument, purpose: 'invalidPurpose'
+        });
+      } catch(e) {
+        error = e;
+      }
+
+      expect(error).to.be.exist;
+      expect(error.message).to
+        .match(/No verification method found for purpose/);
     });
   });
 

--- a/test/driver.spec.js
+++ b/test/driver.spec.js
@@ -137,9 +137,9 @@ describe('did:key method driver', () => {
         error = e;
       }
 
-      expect(error).to.be.exist;
+      expect(error).to.exist;
       expect(error.message).to
-        .match(/No verification method found for purpose/);
+        .contain('No verification method found for purpose');
     });
   });
 


### PR DESCRIPTION
This PR adds a convenience function that can be used in conjunction with a `.get()` to start with a `did:key` DID, and end up with a key for a specific purpose.

For example,

```js
// Start with the DID
const didDocument = await didKeyDriver.get({did});
// This lets you use `publicMethodFor()` to get a key for a specific purpose
const keyAgreementData = didKeyDriver.publicMethodFor({
  didDocument, purpose: 'keyAgreement'
});
const assertionMethodData = didKeyDriver.publicMethodFor({
  didDocument, purpose: 'assertionMethod'
});
// If you're using a `crypto-ld` driver harness, you can create key instances
// which allow you to get access to a `verify()` function.
const assertionMethodPublicKey = await cryptoLd.from(assertionMethodData);
const {verify} = assertionMethodPublicKey.verifier();
```

This addition matches the convenience `methodFor` function that gets returned with `generate()`. The main difference is -- since it's returned by `generate()`, `methodFor` has access to the private key material (and so, can be used for decryption, signing, etc).
Whereas `publicMethodFor` only has access to the public key material (extracted from the DID Document), and is useful by consumers that need those keys for verification and encryption (to a known DID recipient).